### PR TITLE
Updated reload command to Nginx signal

### DIFF
--- a/nginx-modsite
+++ b/nginx-modsite
@@ -138,11 +138,11 @@ ngx_sites() {
 
 ngx_reload() {
 	read -p "Would you like to reload the Nginx configuration now? (Y/n) " reload
-    [[ "$reload" != "n" && "$reload" != "N" ]] && invoke-rc.d nginx reload
+    [[ "$reload" != "n" && "$reload" != "N" ]] && nginx -s reload
 }
 
 ngx_reload_now() {
-	invoke-rc.d nginx reload
+	nginx -s reload
 }
 
 ngx_error() {


### PR DESCRIPTION
Updated reload command to use Nginx's own [Signal](https://docs.nginx.com/nginx/admin-guide/basic-functionality/runtime-control/) as invoke-rc.d was causing errors on Ubuntu 18.04.